### PR TITLE
Allow production disable in parser tests

### DIFF
--- a/src/test/java/me/scai/parsetree/Test_GraphicalProductionSet.java
+++ b/src/test/java/me/scai/parsetree/Test_GraphicalProductionSet.java
@@ -4,11 +4,12 @@ import me.scai.handwriting.TestHelper;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.*;
 
 public class Test_GraphicalProductionSet {
     /* Private members */
@@ -18,6 +19,115 @@ public class Test_GraphicalProductionSet {
     public void setUp() {
         TestHelper.WorkerTuple workerTuple = TestHelper.getTestWorkerTuple();
         gpSet = workerTuple.gpSet;
+    }
+
+    @Test
+    public void testInitiallyAllProdsEnabled() {
+        List<Boolean> prodIsEnabled = gpSet.getProdIsEnabled();
+
+        for (Boolean isEnabled : prodIsEnabled) {
+            assertTrue(isEnabled);
+        }
+
+        assertEquals(gpSet.prods.size(), gpSet.searchIdx.length);
+    }
+
+    @Test
+    public void testDisableEnableProductions() {
+        final int np = gpSet.numProductions();
+
+        for (int k = 0; k < np; ++k) {
+            gpSet.disableProduction(k);
+
+            ArrayList<Boolean> prodIsEnabled = gpSet.getProdIsEnabled();
+            for (int i = 0; i < prodIsEnabled.size(); ++i) {
+                if (i == k) {
+                    assertFalse(prodIsEnabled.get(i));
+                } else {
+                    assertTrue(prodIsEnabled.get(i));
+                }
+            }
+
+            assertEquals(np - 1, gpSet.searchIdx.length);
+
+            for (int idx : gpSet.searchIdx) {
+                assertNotEquals(k, idx);
+            }
+
+            gpSet.enableProduction(k);
+        }
+    }
+
+    @Test
+    public void testEnableAllProductions() {
+        final int np = gpSet.numProductions();
+
+        for (int k = 0; k < np; ++k) {
+            gpSet.disableProduction(k);
+        }
+
+        assertEquals(0, gpSet.searchIdx.length);
+
+        gpSet.enableAllProductions();
+
+        assertEquals(gpSet.prods.size(), gpSet.searchIdx.length);
+        for (int i = 0; i < gpSet.prods.size(); ++i) {
+            assertEquals(i, gpSet.searchIdx[i]);
+        }
+    }
+
+    @Test
+    public void disableProductionBySumString() {
+        assertEquals(gpSet.numProductions(), gpSet.searchIdx.length);
+
+        String prodSumString = gpSet.prods.get(0).sumString;
+
+        int numDisabled = gpSet.disableProductionBySumString(prodSumString);
+
+        assertTrue(numDisabled > 0);
+        assertEquals(gpSet.numProductions() - numDisabled, gpSet.searchIdx.length);
+
+        assertEquals(1, gpSet.searchIdx[0]);
+    }
+
+    @Test
+    public void disableProductionsByLHS() {
+        assertEquals(gpSet.numProductions(), gpSet.searchIdx.length);
+
+
+        final String lhsToDisable = "EXPONENTIATION";
+
+        int numDisabled = gpSet.disableProductionsByLHS(lhsToDisable);
+
+        assertTrue(numDisabled > 0);
+        assertEquals(gpSet.numProductions() - numDisabled, gpSet.searchIdx.length);
+
+        for (int i : gpSet.searchIdx) {
+            assertNotEquals(lhsToDisable, gpSet.prods.get(i).lhs);
+        }
+    }
+
+    @Test
+    public void disabledProductionsByGrammarNodeName() {
+        assertEquals(gpSet.numProductions(), gpSet.searchIdx.length);
+
+        final String grammarNodeNameToDisable = "MATRIX";
+
+        int numDisabled = gpSet.disableProductionsByGrammarNodeName(grammarNodeNameToDisable);
+
+        assertTrue(numDisabled > 0);
+        assertEquals(gpSet.numProductions() - numDisabled, gpSet.searchIdx.length);
+
+        for (int i : gpSet.searchIdx) {
+            GraphicalProduction prod = gpSet.prods.get(i);
+
+            assertNotEquals(grammarNodeNameToDisable, prod.lhs);
+
+            for (String rhsItem : prod.rhs) {
+                assertNotEquals(grammarNodeNameToDisable, rhsItem);
+            }
+        }
+
     }
 
     @Test

--- a/src/test/java/me/scai/parsetree/Test_QADataSet.java
+++ b/src/test/java/me/scai/parsetree/Test_QADataSet.java
@@ -16,6 +16,8 @@ class QADataEntry {
 	private Object correctEvalRes;
     private double[] correctEvalResRange = null;
 
+    private String[] grammarNodesToDisable;
+
 	/* ~Member variables */
 
 	/* Constructors */
@@ -64,6 +66,12 @@ class QADataEntry {
     public QADataEntry withEvalResRange(double lowerBound, double upperBound) {
         return withEvalResRange(new double[] {lowerBound, upperBound});
     }
+
+    public QADataEntry withGrammarNodesDisabled(String[] grammarNodeNames) {
+        this.grammarNodesToDisable = grammarNodeNames;
+
+        return this;
+    }
 	
 	/* Getters */
 	public String getTokenSetFileName() {
@@ -84,6 +92,10 @@ class QADataEntry {
 
     public double[] getCorrectEvalResRange() {
         return correctEvalResRange;
+    }
+
+    public String[] getGrammarNodesToDisable() {
+        return grammarNodesToDisable;
     }
 }
 
@@ -464,7 +476,16 @@ public class Test_QADataSet {
             new QADataEntry("sim_229", "M(2, 34)").withMathTex("M{\\left(2,34\\right)}").withEvalRes(68.0), // Invoke two-argument function
             new QADataEntry("sim_232", "M(2, 34)").withMathTex("M{\\left(2,34\\right)}").withEvalRes(68.0), // Invoke two-argument function
             new QADataEntry("sim_237", "M(3, f(4))").withMathTex("M{\\left(3,f{\\left(4\\right)}\\right)}").withEvalRes(24.0), // Invoke two-argument function, in a nested way
-            new QADataEntry("sim_238", "M(M(1, 2), M(3, 4))").withMathTex("M{\\left(M{\\left(1,2\\right)},M{\\left(3,4\\right)}\\right)}").withEvalRes(24.0), // Invoke two-argument function, in a nested way
+            new QADataEntry("sim_238", "M(M(1, 2), M(3, 4))").withMathTex("M{\\left(M{\\left(1,2\\right)},M{\\left(3,4\\right)}\\right)}")
+                    .withEvalRes(24.0)
+                    .withGrammarNodesDisabled(new String[] {"EXPONENTIATION", "VARIABLE_SYMBOL_SUBSCRIPT",
+                                                            "IF_STATEMENT",  "SWITCH_STATEMENT", "MATRIX",
+                                                            "MATH_FUNCTION_TERM", "MATH_FUNCTION_NAME", "COMPARISON",
+                                                            "LOGICAL_TERM", "LOGICAL_OR_TERM", "DEF_INTEG_TERM",
+                                                            "PI_TERM",
+                                                            "ADDITION", "SUBTRACTION",
+                                                            "MULTIPLICATION", "MULTIPLICATION_VAR",
+                                                            "FRACTION", "SQROOT_TERM"}), // Invoke two-argument function, in a nested way
             new QADataEntry("sim_239", "(B(x, y, z) = ((x / y) + (sqrt(z))))").withMathTex("{B{\\left(x,y,z\\right)}}={{\\frac{x}{y}}+{\\sqrt{z}}}"), // Define three-argument function
             new QADataEntry("sim_240", "B(11, 22, 36)").withMathTex("B{\\left(11,22,36\\right)}").withEvalRes(6.5), // Define three-argument function
             new QADataEntry("sim_241", "(T(x, y) = (x + y))").withMathTex("{T{\\left(x,y\\right)}}={{x}+{y}}") // Define three-argument function

--- a/src/test/java/me/scai/parsetree/Test_TokenSetParser.java
+++ b/src/test/java/me/scai/parsetree/Test_TokenSetParser.java
@@ -45,11 +45,13 @@ public class Test_TokenSetParser {
         stringizer     = workerTuple.stringizer;
         evaluator      = workerTuple.evaluator;
         mathTexifier   = workerTuple.mathTexifier;
+
     }
 
 	@After
 	public void tearDown() throws Exception {
 		evaluator.clearUserData();
+        System.gc();
 	}
 
 	private void testParser(String suiteName) {
@@ -61,7 +63,7 @@ public class Test_TokenSetParser {
         int nTested = 0;
         long totalParsingTime_ms = 0;
 
-        QADataEntry [] entries = qaDataSet.QADataSuites.get(suiteName).getEntries();
+        QADataEntry[] entries = qaDataSet.QADataSuites.get(suiteName).getEntries();
         
         for (int i = 0; i < entries.length; ++i) {
             // for (int i = 0; i < tokenSetNums.length; ++i) {
@@ -89,6 +91,18 @@ public class Test_TokenSetParser {
             } catch (IOException ioe) {
                 System.err.println(ioe.getMessage());
                 System.err.flush();
+            }
+
+            /* Disable grammar productions, if specified */
+            boolean toEnableAllProductions = false;
+            String[] grammarNodesToDisable = entries[i].getGrammarNodesToDisable();
+            if (grammarNodesToDisable != null && grammarNodesToDisable.length > 0) {
+                toEnableAllProductions = true;
+                for (String grammarNode : grammarNodesToDisable) {
+                    int numDisabled =
+                            tokenSetParser.getGraphicalProductionSet().disableProductionsByGrammarNodeName(grammarNode);
+                    System.out.println("Disabled " + numDisabled + " production(s) with grammar node name " + grammarNode);
+                }
             }
 
             /* Parse graphically */
@@ -204,6 +218,12 @@ public class Test_TokenSetParser {
             } else {
                 System.err.println(strPrint);
                 System.err.flush();
+            }
+
+            /* If necessray, re-enable all grammar productions */
+            if (toEnableAllProductions) {
+                tokenSetParser.getGraphicalProductionSet().enableAllProductions();
+                System.out.println("Enabled all productions.");
             }
 
             nTested++;


### PR DESCRIPTION
GraphicalProductionSet can now have individual productions disabled (by sum string, LHS, or any LHS/RHS).

Productions can be disabled on a token-set-by-token-set basis in Test_TokenSetParser, to speed up parsing and reduce memory consumption.
